### PR TITLE
8/2/22 - The share option through kebab menu is now working. The app …

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
@@ -51,6 +51,7 @@ import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetail
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -182,13 +183,15 @@ public class TasksFragment extends Fragment implements TasksContract.View {
             case R.id.menu_share:
                 String email = PreferenceManager
                         .getDefaultSharedPreferences(getContext())
-                        .getString("email_text", "");
-                Intent shareIntent = new Intent();
+                        .getString("email_edit_text", "");
+
+                Intent shareIntent = new Intent(Intent.ACTION_SEND);
                 shareIntent.setType("text/plain");
                 shareIntent.putExtra(Intent.EXTRA_TEXT, getTaskListAsArray());
-                shareIntent.putExtra(Intent.EXTRA_EMAIL, email);
+                shareIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{email});
+
                 startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.share_to)));
-                //startActivity(shareIntent);
+
                 break;
         }
         return true;


### PR DESCRIPTION
…was not launching the intent chooser, and sometimes crashing.

Changes made/required:
#186 - a wrong key reference to editTextPreference key. The reference was missing '_edit_'. Hence, was not populating the 'To' field in the Gmail along with corrections on #188 and #191.

#188 - added Intent.ACTION_SEND because we are sending data. This was the main issue that caused the app crash.

#191 - Intent.EXTRA_EMAIL takes a String[] as a value, not a string object. This was causing 'To' field to be empty.